### PR TITLE
Handle vtt file that has no captions

### DIFF
--- a/SubtitlesParser/Classes/Parsers/SubParser.cs
+++ b/SubtitlesParser/Classes/Parsers/SubParser.cs
@@ -118,19 +118,11 @@ namespace SubtitlesParser.Classes.Parsers
                 {
                     var parser = subtitlesParser.Value;
                     var items = parser.ParseStream(seekableStream, encoding);
-
-                    // safeguard
-                    if (items.Any())
-                    {
-                        return items;
-                    }
-                    else
-                    {
-                        throw new FormatException(string.Format("Failed to parse as {0}", subtitlesParser.Key));
-                    }
+                    return items;
                 }
                 catch(Exception ex)
                 {
+                    throw new FormatException(string.Format("Failed to parse as {0}", subtitlesParser.Key), ex);
                     //Console.WriteLine(ex);
                 }
             }

--- a/SubtitlesParser/Classes/Parsers/VttParser.cs
+++ b/SubtitlesParser/Classes/Parsers/VttParser.cs
@@ -93,14 +93,7 @@ namespace SubtitlesParser.Classes.Parsers
                     }
                 }
 
-                if (items.Any())
-                {
-                    return items;
-                }
-                else
-                {
-                    throw new ArgumentException("Stream is not in a valid VTT format");
-                }
+                return items;
             }
             else
             {

--- a/Test/Content/TestFiles/Example With Comments.vtt
+++ b/Test/Content/TestFiles/Example With Comments.vtt
@@ -1,0 +1,21 @@
+﻿WEBVTT
+
+NOTE
+This file was written by Jill. I hope
+you enjoy reading it. Some things to
+bear in mind:
+- I was lip-reading, so the cues may
+not be 100% accurate
+- I didn’t pay too close attention to
+when the cues should start or end.
+
+00:01.000 --> 00:04.000
+Never drink liquid nitrogen.
+
+NOTE check next cue
+
+00:05.000 --> 00:09.000
+— It will perforate your stomach.
+— You could die.
+
+NOTE end of file

--- a/Test/Content/TestFiles/No Captions - With comment block.vtt
+++ b/Test/Content/TestFiles/No Captions - With comment block.vtt
@@ -1,0 +1,5 @@
+﻿WEBVTT
+
+NOTE
+duration:"00:00:00"
+language:En-US

--- a/Test/Program.cs
+++ b/Test/Program.cs
@@ -39,7 +39,7 @@ namespace Test
                         }
                         else
                         {
-                            throw new ArgumentException("Not items found!");
+                            Console.WriteLine("Parsing of file {0}: SUCCESS (No items found!)", fileName, items.Count);
                         }
                         
                     }


### PR DESCRIPTION
These changes update the vtt parser to not throw if it parses and does not find any captions. Under normal circumstances this is not an issue but technically a vtt file without captions is still valid. Ideally maybe this behavior would be based on how you configure the parser but for now this helps us handle empty vtt files.