### PR TITLE
Fixed Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
 ## SubtitlesParser
-===============
 
 Universal subtitles parser which aims at supporting all subtitle formats.
 For more info on subtitles formats, see this page: http://en.wikipedia.org/wiki/Category:Subtitle_file_formats
@@ -26,7 +25,7 @@ You can check the Test project for subtitles files and more sample codes.
 If you don't specify the subtitle format, the SubtitlesParser will try all the registered parsers (7 for now)
 
 ```csharp
-var parser = new SubtitlesParser.Classes.Parsers.SubtitlesParser();
+var parser = new SubtitlesParser.Classes.Parsers.SubParser();
 using (var fileStream = File.OpenRead(pathToSrtFile)){
 	var items = parser.ParseStream(fileStream);
 }


### PR DESCRIPTION
SubtitleParser does not exist anymore and was renamed to SubParser (see Commit https://github.com/AlexPoint/SubtitlesParser/commit/d65867b92f41a30ce11421a44add35606be58fad). I also removed the superflous formatting for the header of the readme file.