### PR TITLE
Fix for creating invalid subtitles

### DIFF
--- a/SubtitlesParser/Classes/Parsers/TtmlParser.cs
+++ b/SubtitlesParser/Classes/Parsers/TtmlParser.cs
@@ -36,7 +36,9 @@ namespace SubtitlesParser.Classes.Parsers
                         .Replace("<tt:", "<")
                         .Replace("</tt:", "</")
                         .Replace(string.Format(@" xmlns:tt=""{0}""", tt), "")
-                        .Replace(string.Format(@" xmlns=""{0}""", tt), "");
+                        .Replace(string.Format(@" xmlns=""{0}""", tt), "")
+                        .TrimStart('\n')
+                        .TrimEnd('\n');
 
                     items.Add(new SubtitleItem()
                     {


### PR DESCRIPTION
Fix for creating invalid SRT subtitles, subtitle lines cannot start or end with a new line (i.e. empty lines)

When using a TTXT file like

```
<tt>
  <head>
    <style font="Arial" size="20" color="white" backgroundColor="black"/>
  </head>
  <body>
    <div tts_region="subtitle">
      <p begin="00:00:05.000" end="00:00:10.000">
        This is the first subtitle.
      </p>
      <p begin="00:00:11.500" end="00:00:15.000">
        This is the second one.
      </p>
    </div>
  </body>
</tt>
```

This leads to an invalid subtitle file when saving as an SRT by introducing empty lines between the timestamps and the subtitle text. Leading and lagging new lines should be stripped out as they don't contain any information anyway and end up violating the specs inadvertently.